### PR TITLE
fix Links

### DIFF
--- a/src/content/projects/link/index.mdx
+++ b/src/content/projects/link/index.mdx
@@ -21,7 +21,7 @@ https://www.yellowdogman.com/
 Resoniteを開発している会社。チェコにあるそうな
 
 ### Resonite (Discord)
-https://discord.gg/resonite/  
+https://discord.gg/resonite  
 Resoniteチームが運営しているDiscordサーバー。最新版リリース情報や、ユーザコミュニティによるイベント告知、こんなん作ったよというフォーラム、ペットを自慢するだけの雑談トピックなどかなり活発に動いている。
 
 ### Resonite Patreon

--- a/src/content/projects/link/index.mdx
+++ b/src/content/projects/link/index.mdx
@@ -120,7 +120,7 @@ noteやZennの記事が寄稿されていることが多い
 
 ### Github Resonite-issues
 https://github.com/Yellow-Dog-Man/Resonite-Issues/issues  
-ユーザの要望、不具合報告、将来的に実装する機能についての議論をするところ。 開発陣がよく見ていて、なにやらコメントしたりしています
+ユーザの要望、不具合報告、将来的に実装したい機能についての議論をするところ。 開発陣がよく見ていて、なにやらコメントしたりしています
 
 Resoniteの民がIssueといっていたらここに建てるトピックのことを指すことが多い
 
@@ -130,7 +130,7 @@ https://www.resonitemerch.com/
 <small>Publicフォルダの Resonite Essentials の中に、PVに出てきたTシャツとハンガーの3Dモデルがある（余談）</small>
 
 ### Twitch Resoniteカテゴリ
-@@カテゴリへのURLを張る@@
+https://twitch.tv/directory/category/resonite
 
 - 運営・開発チームの定期配信
 - CreatorJamコミュニティの配信
@@ -142,7 +142,7 @@ https://www.resonitemerch.com/
 
 ### ResoniteJapan (Discord)
 https://discord.gg/resonite-japan  
-日本コミュニティのDiscordサーバー。イベントの告知や雑談のほか、おすすめPCスペックなどなんでも書くフォーラムがある。  
+日本コミュニティのDiscordサーバー。イベントの告知や雑談のほか、おすすめPCスペックなどなんでも書くフォーラムがある。ROM専でも大丈夫なので日本語の情報が欲しい人は覗くと幸せになれるかも  
 
 ### Resonite.love
 https://misskey.resonite.love/  


### PR DESCRIPTION
- TwitchのResoniteカテゴリへのURLが下書きだったのを修正
- コメントを修正